### PR TITLE
Fix formal formality endings (usted/ustedes)

### DIFF
--- a/lib/inflect.js
+++ b/lib/inflect.js
@@ -355,6 +355,7 @@ var inflect = function(verb, options) {
 	var positivity = options && options.positivity || "affirmative";
 	var reflection = options && !!options.reflection;
 	var formality = options && options.formality || "formal";
+	var hasFormality = options && (options.formality === "formal" || options.formality === "informal");
 	var styling = options && (options.style && styles[options.style]) || styles["castillano"];
 
 	if (styling.tuteo && person === "second" && number === "singular" && formality === "formal") {
@@ -365,6 +366,11 @@ var inflect = function(verb, options) {
 	if (styling.ustedes && person === "second" && number === "plural") {
 		// in ustedes regions, the plural of tu is not vosotros, but ustedes instead,
 		// which is the same as the third person plural
+		person = "third";
+	}
+
+	if (hasFormality && person === "second" && formality === "formal") {
+		// formal second person (usted/ustedes) uses third person verb endings
 		person = "third";
 	}
 

--- a/test/testInflect.js
+++ b/test/testInflect.js
@@ -3983,6 +3983,56 @@ module.exports = {
         test.done();
     },
 
+    testFormalityAffectsEndings: function(test) {
+
+        test.equal("habla", inflect("hablar", {
+            person: "second",
+            number: "singular",
+            mood: "indicative",
+            tense: "present",
+            formality: "formal",
+            style: "castillano"
+        }));
+
+        test.equal("hablan", inflect("hablar", {
+            person: "second",
+            number: "plural",
+            mood: "indicative",
+            tense: "present",
+            formality: "formal",
+            style: "castillano"
+        }));
+
+        test.equal("hablas", inflect("hablar", {
+            person: "second",
+            number: "singular",
+            mood: "indicative",
+            tense: "present",
+            formality: "informal",
+            style: "castillano"
+        }));
+
+        test.equal("habláis", inflect("hablar", {
+            person: "second",
+            number: "plural",
+            mood: "indicative",
+            tense: "present",
+            formality: "informal",
+            style: "castillano"
+        }));
+
+        test.equal("hablas", inflect("hablar", {
+            person: "second",
+            number: "singular",
+            mood: "indicative",
+            tense: "present",
+            formality: "formal",
+            style: "caribeno"
+        }));
+
+        test.done();
+    },
+
     testConjugateRegularVerbs: function(test) {
 
         Object.keys(tests).forEach(function(verb) {


### PR DESCRIPTION
Map explicit formality: "formal" to third‑person verb endings in inflect.js, after existing tuteo/ustedes handling. I added tests covering formal/informal behavior and the caribeno tuteo override, but there are some other tests failing at the moment. 

Why
Spanish formal second person (usted/ustedes) takes third‑person endings. Previously formality only affected pronouns, so inflect() could produce “usted + 2nd‑person endings”.

